### PR TITLE
TASK: Add target="_blank" to links in PageList partial

### DIFF
--- a/Resources/Private/Partials/Module/FeatureModule/PageList.html
+++ b/Resources/Private/Partials/Module/FeatureModule/PageList.html
@@ -10,7 +10,7 @@
                             {page.properties.title}
                         </td>
                         <td>
-                            <neos:link.node node="{page}" class="neos-pull-right"><i class="fas fa-eye"></i></neos:link.node>
+                            <neos:link.node node="{page}" class="neos-pull-right" target="_blank" rel="noopener noreferrer"><i class="fas fa-eye"></i></neos:link.node>
                         </td>
                     </tr>
                 </f:for>


### PR DESCRIPTION
I found it to be quite disorienting to leave the backend entirely when clicking on a preview link., so in order to improve UX, I'd like to suggest to open the page preview links in a new tab.

Thanks for this great module! 