### PR TITLE
BUGFIX: Add privilegeTarget to module configuration

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -26,6 +26,7 @@ Neos:
             label: 'Features'
             description: 'Configurations of A/B Testing Features'
             controller: Wysiwyg\ABTesting\Controller\Module\AbTesting\FeatureModuleController
+            privilegeTarget: Wysiwyg.ABTesting:Module.AbTesting.Feature
             widgetTemplatePathAndFileName: 'resource://Neos.Neos/Private/Templates/Module/Widget.html'
             actions:
               newFeature:


### PR DESCRIPTION
The link to the Feature module should not be shown to editors that are not AB Testers or Administrators.