### PR TITLE
Bugfix: Optimize cache annotations

### DIFF
--- a/Resources/Private/Fusion/NodeTypes/ABTestingContainer.fusion
+++ b/Resources/Private/Fusion/NodeTypes/ABTestingContainer.fusion
@@ -18,15 +18,10 @@ prototype(Wysiwyg.ABTesting:ABTestingContainer) < prototype(Neos.Neos:ContentCom
     @cache {
         mode = 'dynamic'
         entryIdentifier {
-            0 = ${node}
-            1 = ${feature}
-            2 = ${testCase}
+            node = ${node}
         }
 
-        entryDiscriminator = Neos.Fusion:Collection {
-            0 = ${feature}
-            1 = ${testCase}
-        }
+        entryDiscriminator = ${Wysiwyg.ABTesting.Decisions.getDecisionForFeature(feature, request.arguments.forceABVersion)}
 
         entryTags {
             1 = ${Neos.Caching.nodeTag(node)}
@@ -34,8 +29,9 @@ prototype(Wysiwyg.ABTesting:ABTestingContainer) < prototype(Neos.Neos:ContentCom
 
         context {
             1 = 'node'
-            2 = 'testCase'
-            3 = 'feature'
+            2 = 'documentNode'
+            3 = 'site'
+            4 = 'feature'
         }
     }
 }


### PR DESCRIPTION
The previous cache annotations had the following issues.

- Missing 'site' and 'documentNode' in context which caused trouble during evaluating of global cache indentifiers
- Needlessly complex Discriminator that relied on the context
- Adding the decision to the context, correct is adding the feature and letting the discriminator decide which cache entry is to be rendered
- The entry identifier was too complex, the node is enough as this identifies the container