### PR TITLE
TASK: Neos 5.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "neos-plugin",
     "require": {
         "php": ">=7.1",
-        "neos/neos": ">3.2 <6.0"
+        "neos/neos": ">=4.3 <6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "neos-plugin",
     "require": {
         "php": ">=7.1",
-        "neos/neos": ">3.2 <5.0"
+        "neos/neos": ">3.2 <6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The changes adjusts the version constraints and the handling of the request plus response to only use the psr 7 methods to support Neos 4.3 and 5.x.